### PR TITLE
update grunt-connect-proxy to v 0.2.0

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -9,7 +9,7 @@
     "grunt-bowercopy": "~0.4.1",
     "grunt-bower-install": "~0.7.0",
     "grunt-concurrent": "~0.4.2",
-    "grunt-connect-proxy": "~0.1.7",
+    "grunt-connect-proxy": "~0.2.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-connect": "~0.5.0",


### PR DESCRIPTION
The current grunt-connect-proxy version used is causing the angular app to emit an error that has been [documented](https://github.com/drewzboto/grunt-connect-proxy/pull/96) by the grunt-connect-proxy team and fixed in version 0.2.0 :

```
grunt server --verbose
Initializing
Command-line options: --verbose

Reading "Gruntfile.js" Gruntfile...OK

Registering Gruntfile tasks.
Loading "Gruntfile.js" tasks...ERROR
>> TypeError: Cannot read property 'prototype' of undefined
>>     at Object.exports.inherits (util.js:634:43)
>>     at Object.<anonymous> (/Users/j/repos/ccd/node_modules/grunt-connect-proxy/node_modules/http-proxy/lib/http-proxy/index.js:106:17)
>>     at Module._compile (module.js:460:26)
>>     at Object.Module._extensions..js (module.js:478:10)
>>     at Module.load (module.js:355:32)
>>     at Function.Module._load (module.js:310:12)
>>     at Module.require (module.js:365:17)
>>     at require (module.js:384:17)
>>     at Object.<anonymous> (/Users/j/repos/ccd/node_modules/grunt-connect-proxy/node_modules/http-proxy/lib/http-proxy.js:4:17)
>>     at Module._compile (module.js:460:26)

Running tasks: server
Warning: Task "server" not found. Use --force to continue.
```

This pull request updates the grunt-http-proxy version.
